### PR TITLE
Deprecate repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,5 @@
 # criticalmaps-web
 
-[![Build Status](https://travis-ci.org/criticalmaps/criticalmaps-web.svg?branch=master)](https://travis-ci.org/criticalmaps/criticalmaps-web)
+🚨🚨🚨 DEPRECATED 🚨🚨🚨
 
-Website repository for [criticalmaps.net](http://criticalmaps.net/)
-
-## Run in development mode
-
-```
-docker build -f Dockerfile.dev -t criticalmaps-web . && docker run -v $(pwd):/go/src/github.com/criticalmaps/criticalmaps-web/ -p 3000:3000 criticalmaps-web
-```
+in favor of [github.com/criticalmaps/criticalmaps.github.io](https://github.com/criticalmaps/criticalmaps.github.io).


### PR DESCRIPTION
fyi @criticalmaps/web 

i moved everything into https://github.com/criticalmaps/criticalmaps.github.io where we will be hosting via github pages in the future.